### PR TITLE
Forward Destination & Grafana NaN Fix

### DIFF
--- a/grafana/Pi-hole.json
+++ b/grafana/Pi-hole.json
@@ -653,7 +653,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Max"
+              "options": "Last"
             },
             "properties": [
               {
@@ -794,7 +794,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Max"
+              "options": "Last"
             },
             "properties": [
               {
@@ -935,7 +935,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Max"
+              "options": "Last"
             },
             "properties": [
               {

--- a/pihole-influxdb.py
+++ b/pihole-influxdb.py
@@ -276,14 +276,16 @@ class PiholeInfluxDB():
                 WritePrecision.S
             ))
         if 'forward_destinations' in stats:
+            forward_destinations = stats.pop('forward_destinations')
             points.append(Point.from_dict(
                 {
                     "measurement": "forward_destinations",
                     "tags": tags,
-                    "fields": stats.pop('forward_destinations'),
+                    "fields": forward_destinations,
                     "time": now_seconds
                 },
-                WritePrecision.S
+                WritePrecision.S,
+                field_types={x: "float" for x in forward_destinations}
             ))
         if 'querytypes' in stats:
             points.append(Point.from_dict(


### PR DESCRIPTION
Introduc two fixes.
1. For the error when processing forward_destination related to float / int type issues
2. For the Grafana Dashboard that shows NaN values on the tables